### PR TITLE
fix bug where you couldn't add files

### DIFF
--- a/lib/weh.js
+++ b/lib/weh.js
@@ -13,9 +13,9 @@ function siteConfig (conf = {}) {
   this._config = generateConfig(conf)
 }
 
-function _runMiddleware (hooks, ...args) {
+function _runMiddleware (hooks, files) {
   return new Promise((resolve, reject) => {
-    hooks.run(...args, (err, res) => {
+    hooks.run(files, (err, res) => {
       if (err) reject(err)
       resolve(res)
     })
@@ -34,7 +34,7 @@ async function buildSite (site) {
   }
 
   debug('running plugins...')
-  await _runMiddleware(site.hooks, site.files)
+  site.files = await _runMiddleware(site.hooks, site.files)
 
   debug('got %d files', site.files.length)
   if (site._config.dry_run) {


### PR DESCRIPTION
this bug would occur whenever you did something like this:

```js
weh(site => {
  // etc
  site.use(() => files => [...files, { path: 'a.md', contents: 'hi' }])
  // etc
})
```

the `a.md` file would end up not getting written to disk